### PR TITLE
DP-2066: Enable backoff for retries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## ?.?.?
+
+* Enabled retry backoff factor for requests to Keycloak.
+
 ## 0.1.0
 
 * Initial release.

--- a/okdata/resource_auth/authorizer.py
+++ b/okdata/resource_auth/authorizer.py
@@ -1,7 +1,9 @@
 import os
 import urllib.parse
 
-import requests
+from requests import Session
+from requests.adapters import HTTPAdapter
+from requests.packages.urllib3.util.retry import Retry
 
 
 class ResourceAuthorizer:
@@ -26,7 +28,12 @@ class ResourceAuthorizer:
             "Content-Type": "application/x-www-form-urlencoded",
         }
 
-        response = requests.post(
+        session = Session()
+        adapter = HTTPAdapter(max_retries=Retry(total=3, backoff_factor=0.5))
+        session.mount("https://", adapter)
+        session.mount("http://", adapter)
+
+        response = session.post(
             url=urllib.parse.urljoin(
                 self.keycloak_server_url,
                 f"/auth/realms/{self.keycloak_realm}/protocol/openid-connect/token",


### PR DESCRIPTION
Attempt to evade connection issues, while at the same time not causing lambda timeouts. Not sure what the "sweet spot" is in this case.