### PR TITLE
T#209 Don't error out on 4XX responses from KC

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: [3.7, 3.8, 3.9]
+        python: ['3.7', '3.8', '3.9', '3.10']
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,15 @@
+## ?.?.?
+
+* `ResourceAuthorizer.has_access` now returns `False` on all 4XX responses from
+  Keycloak instead of raising an exception, not only for 403 responses.
+
 ## 0.1.3
 
-* Fix retry on POST requests to Keycloak
+* Fix retry on POST requests to Keycloak.
 
 ## 0.1.2
 
-* Set timeout for requests to Keycloak
+* Set timeout for requests to Keycloak.
 
 ## 0.1.1
 

--- a/okdata/resource_auth/authorizer.py
+++ b/okdata/resource_auth/authorizer.py
@@ -50,7 +50,7 @@ class ResourceAuthorizer:
         has_access = False
         if response.status_code == 200:
             has_access = response.json()["result"]
-        elif response.status_code == 403:
+        elif 400 <= response.status_code < 500:
             pass
         else:
             response.raise_for_status()

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py37,py38,py39,flake8,black
+envlist = py37,py38,py39,py310,flake8,black
 
 [testenv]
 deps=


### PR DESCRIPTION
Return `False` from `ResourceAuthorizer.has_access` on all 4XX responses from Keycloak instead of raising an exception, not only for 403 responses.